### PR TITLE
Use a maintained fork of unicode_names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [dependencies]
-unicode_names = { git = 'https://github.com/Jokler/unicode_names', rev = 'd97b80c3c35b9f1d04085409087ef113c94cde17' }
+unicode_names2 = "0.2.1"
 unicode-width = "0.1.5"
 byteorder = "1"
 lazy_static = "1.0.0"

--- a/src/display.rs
+++ b/src/display.rs
@@ -4,7 +4,7 @@ use std::char;
 use std::convert;
 
 use byteorder::{BigEndian, ByteOrder};
-use unicode_names;
+use unicode_names2;
 use unicode_width::UnicodeWidthChar;
 
 use super::ascii;
@@ -23,7 +23,7 @@ impl fmt::Display for Describable {
         try!(cp.fmt(f));
         let printable: Printable = self.c.into();
         try!(write!(f, "\n{}", printable));
-        let unicode_name = unicode_names::name(self.c);
+        let unicode_name = unicode_names2::name(self.c);
         if let Some(n) = unicode_name.clone() {
             try!(write!(f, "\nUnicode name: {}", n));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ extern crate byteorder;
 extern crate fst;
 #[macro_use]
 extern crate lazy_static;
-extern crate unicode_names;
+extern crate unicode_names2;
 extern crate unicode_width;
 
 use std::env;


### PR DESCRIPTION
Given that the author of unicode_names is unresponsive since 2016, I forked unicode_names as "unicode_names2".