### PR TITLE
Update unicode_names2 to the latest for Unicode 12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "chars"
 path = "src/main.rs"
 
 [dependencies]
-unicode_names2 = "0.2.1"
+unicode_names2 = "0.3.0"
 unicode-width = "0.1.5"
 byteorder = "1"
 lazy_static = "1.0.0"

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -16,5 +16,5 @@ regex = "0.1"
 lazy_static = "0.2.1"
 fst = "0.1"
 quick-error = "1.1.0"
-unicode_names2 = "0.2.1"
+unicode_names2 = "0.3.0"
 getopts = "0" # This should go in the bin deps section once https://github.com/rust-lang/cargo/issues/1982 is in.

--- a/generator/src/unicode.rs
+++ b/generator/src/unicode.rs
@@ -216,7 +216,6 @@ pub fn read_names(names: &mut fst_generator::Names, file: &Path) -> Result<(), E
                     LineType::Simple | LineType::None | LineType::BlockStart(_) => {
                         return Err(Error::Block(start));
                     }
-                    // TODO: update to inclusive range syntax when it's stable:
                     LineType::BlockEnd(end) => {
                         for i in start..=end {
                             if let Some(ch) = char::from_u32(i as u32) {

--- a/tests/human_names.proptest-regressions
+++ b/tests/human_names.proptest-regressions
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 xs 1748813645 2451531769 237672694 1721398382 # shrinks to ch = '㐀'
+xs 2889640060 749689807 417206124 1471392640 # shrinks to ch = '𬺰'

--- a/tests/human_names.rs
+++ b/tests/human_names.rs
@@ -18,6 +18,8 @@ fn diagnostics(ch: char, query: &str) -> String {
 }
 
 proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100000))]
+
     #[test]
     fn find_any_by_identity(ch in prop::char::any()) {
         let mut chstr = String::new();


### PR DESCRIPTION
This nets us the lobster emojo's name:

```
U+0001F99E, &#129438; 0x0001F99E, \0374636, UTF-8: f0 9f a6 9e, UTF-16BE: d83edd9e
Width: 1, prints as 🦞
Quotes as \u{1f99e}
Unicode name: LOBSTER
```