### PR TITLE
Eliminate clippy lints & warnings for 1.41

### DIFF
--- a/chars/tests/human_names.rs
+++ b/chars/tests/human_names.rs
@@ -1,6 +1,5 @@
-#[macro_use]
-extern crate proptest;
 extern crate chars;
+extern crate proptest;
 extern crate unicode_names2;
 
 use chars::human_names;

--- a/chars_data/src/ascii.rs
+++ b/chars_data/src/ascii.rs
@@ -72,7 +72,7 @@ fn split_name_line(line: &str) -> Vec<String> {
     let line = line.trim_start_matches('"');
     QUOTES
         .split(line)
-        .map(|s| BACKSLASH_SOMETHING.replace_all(s, "$1").to_owned())
+        .map(|s| BACKSLASH_SOMETHING.replace_all(s, "$1"))
         .collect()
 }
 

--- a/chars_data/src/fst_generator.rs
+++ b/chars_data/src/fst_generator.rs
@@ -46,7 +46,7 @@ fn add_component(result: &mut Vec<String>, component: &str) {
 
 fn name_components(name: &str) -> Vec<String> {
     let mut result = vec![];
-    result.push(name.to_lowercase().to_owned());
+    result.push(name.to_lowercase());
     for component in name.split_whitespace() {
         add_component(&mut result, component);
     }

--- a/chars_data/src/unicode.rs
+++ b/chars_data/src/unicode.rs
@@ -75,7 +75,7 @@ fn process_line(names: &mut fst_generator::Names, line: &str) -> Result<LineType
         names.insert(vec![query], ch);
         match fields.get(10) {
             Some(&"") | None => {}
-            Some(name) => names.insert(vec![name.to_string()], ch),
+            Some(&name) => names.insert(vec![name.to_string()], ch),
         }
         Ok(LineType::Simple)
     } else {


### PR DESCRIPTION
This will undoubtedly make the build-time generation of things a tiny bit faster (: