### PR TITLE
Rename structs & enum variants to fit rust's "only capitalize" convention

### DIFF
--- a/chars/src/display.rs
+++ b/chars/src/display.rs
@@ -134,7 +134,7 @@ impl fmt::Display for Printable {
 }
 
 enum Codepoint {
-    ASCII7bit(char),
+    Ascii7Bit(char),
     Latin1(char),
     UnicodeBasic(char),
     UnicodeWide(char),
@@ -143,7 +143,7 @@ enum Codepoint {
 impl convert::From<char> for Codepoint {
     fn from(c: char) -> Codepoint {
         match c as u32 {
-            0..=0x7F => Codepoint::ASCII7bit(c),
+            0..=0x7F => Codepoint::Ascii7Bit(c),
             0x80..=0xFF => Codepoint::Latin1(c),
             0x0100..=0xFFFF => Codepoint::UnicodeBasic(c),
             _ => Codepoint::UnicodeWide(c),
@@ -154,7 +154,7 @@ impl convert::From<char> for Codepoint {
 impl fmt::Display for Codepoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
-            Codepoint::ASCII7bit(c) => {
+            Codepoint::Ascii7Bit(c) => {
                 let num = c as u32;
                 write!(
                     f,
@@ -203,8 +203,8 @@ impl fmt::Display for Codepoint {
 }
 
 enum ByteRepresentation {
-    UTF8(Vec<u8>),
-    UTF16BE(Vec<u8>),
+    Utf8(Vec<u8>),
+    Utf16Be(Vec<u8>),
 }
 
 impl<'a> convert::From<str::EncodeUtf16<'a>> for ByteRepresentation {
@@ -217,28 +217,28 @@ impl<'a> convert::From<str::EncodeUtf16<'a>> for ByteRepresentation {
             buf.extend_from_slice(&split_word);
         }
 
-        ByteRepresentation::UTF16BE(buf)
+        ByteRepresentation::Utf16Be(buf)
     }
 }
 
 impl<'a> convert::From<str::Bytes<'a>> for ByteRepresentation {
     fn from(bs: str::Bytes<'a>) -> ByteRepresentation {
         let bytes: Vec<u8> = bs.collect();
-        ByteRepresentation::UTF8(bytes)
+        ByteRepresentation::Utf8(bytes)
     }
 }
 
 impl fmt::Display for ByteRepresentation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
-            ByteRepresentation::UTF8(ref bytes) => {
+            ByteRepresentation::Utf8(ref bytes) => {
                 let mut byte_iter = bytes.iter();
                 write!(f, "{:02x}", byte_iter.next().unwrap())?;
                 for byte in byte_iter {
                     write!(f, " {:02x}", byte)?;
                 }
             }
-            ByteRepresentation::UTF16BE(ref bytes) => {
+            ByteRepresentation::Utf16Be(ref bytes) => {
                 for byte in bytes.iter() {
                     write!(f, "{:02x}", byte)?;
                 }

--- a/chars_data/src/ascii.rs
+++ b/chars_data/src/ascii.rs
@@ -35,7 +35,7 @@ use regex::Regex;
 use crate::fst_generator;
 
 #[derive(Debug, Clone)]
-struct ASCIIEntry {
+struct AsciiEntry {
     value: char,
     mnemonics: Vec<String>,
     synonyms: Vec<String>,
@@ -43,13 +43,13 @@ struct ASCIIEntry {
 }
 
 #[derive(Debug)]
-struct ASCIIForDisplay<'a> {
-    val: &'a ASCIIEntry,
+struct AsciiForDisplay<'a> {
+    val: &'a AsciiEntry,
 }
 
-impl ASCIIEntry {
-    fn new(code: u8) -> ASCIIEntry {
-        ASCIIEntry {
+impl AsciiEntry {
+    fn new(code: u8) -> AsciiEntry {
+        AsciiEntry {
             value: code as char,
             mnemonics: vec![],
             synonyms: vec![],
@@ -57,8 +57,8 @@ impl ASCIIEntry {
         }
     }
 
-    fn for_display(&self) -> ASCIIForDisplay<'_> {
-        ASCIIForDisplay { val: self }
+    fn for_display(&self) -> AsciiForDisplay<'_> {
+        AsciiForDisplay { val: self }
     }
 }
 
@@ -89,11 +89,11 @@ fn test_split_name_line() {
 
 const NAMETABLE: &[u8] = include_bytes!("../data/ascii/nametable");
 
-fn process_ascii_nametable() -> Result<Vec<ASCIIEntry>, io::Error> {
+fn process_ascii_nametable() -> Result<Vec<AsciiEntry>, io::Error> {
     let mut char_code: u8 = 0;
 
-    let mut entry = ASCIIEntry::new(char_code);
-    let mut entries: Vec<ASCIIEntry> = vec![];
+    let mut entry = AsciiEntry::new(char_code);
+    let mut entries: Vec<AsciiEntry> = vec![];
 
     let reader = Cursor::new(NAMETABLE);
     for line in reader.lines() {
@@ -105,7 +105,7 @@ fn process_ascii_nametable() -> Result<Vec<ASCIIEntry>, io::Error> {
                 if line == "%%" {
                     entries.push(entry);
                     char_code += 1;
-                    entry = ASCIIEntry::new(char_code);
+                    entry = AsciiEntry::new(char_code);
                     continue;
                 }
                 // Otherwise, not at a spec boundary. Let's add names:
@@ -132,7 +132,7 @@ fn process_ascii_nametable() -> Result<Vec<ASCIIEntry>, io::Error> {
     Ok(entries)
 }
 
-impl<'a> fmt::Display for ASCIIForDisplay<'a> {
+impl<'a> fmt::Display for AsciiForDisplay<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let val = self.val.clone();
         write!(

--- a/chars_data/src/fst_generator.rs
+++ b/chars_data/src/fst_generator.rs
@@ -43,8 +43,7 @@ fn add_component(result: &mut Vec<String>, component: &str) {
 }
 
 fn name_components(name: &str) -> Vec<String> {
-    let mut result = vec![];
-    result.push(name.to_lowercase());
+    let mut result = vec![name.to_lowercase()];
     for component in name.split_whitespace() {
         add_component(&mut result, component);
     }


### PR DESCRIPTION
I disagree with it, but clippy complains so what are we to do.